### PR TITLE
fix(docs): Add missing await in examples

### DIFF
--- a/docs/directory-operations.md
+++ b/docs/directory-operations.md
@@ -5,7 +5,7 @@
 To create a directory, use the `fsx.createDirectory(dirPath)` method, like this:
 
 ```js
-fsx.createDirectory("/path/to/directory");
+await fsx.createDirectory("/path/to/directory");
 ```
 
 > [!TIP]
@@ -19,7 +19,7 @@ fsx.createDirectory("/path/to/directory");
 To determine to if a directory exists, use the `fsx.isDirectory(dirPath)` method, which returns `true` if the given directory exists or `false` otherwise.
 
 ```js
-if (fsx.isdirectory("/path/to/directory")) {
+if (await fsx.isdirectory("/path/to/directory")) {
     // handle the directory
 }
 ```
@@ -32,7 +32,7 @@ if (fsx.isdirectory("/path/to/directory")) {
 To delete directories, call the `fsx.delete(dirPath)` method. For example:
 
 ```js
-fsx.delete("/path/to/directories");
+await fsx.delete("/path/to/directories");
 ```
 
 > [!IMPORTANT]

--- a/docs/file-operations.md
+++ b/docs/file-operations.md
@@ -72,7 +72,7 @@ fsx.write("/path/to/file.txt", buffer);
 To determine to if a file exists, use the `fsx.isFile(filePath)` method, which returns `true` if the given file exists or `false` otherwise.
 
 ```js
-if (fsx.isFile("/path/to/file.txt")) {
+if (await fsx.isFile("/path/to/file.txt")) {
     // handle the file
 }
 ```
@@ -85,5 +85,5 @@ if (fsx.isFile("/path/to/file.txt")) {
 To delete files, call the `fsx.delete(filePath)` method. For example:
 
 ```js
-fsx.delete("/path/to/file.txt");
+await fsx.delete("/path/to/file.txt");
 ```

--- a/docs/file-operations.md
+++ b/docs/file-operations.md
@@ -57,11 +57,11 @@ To write files, call the `fsx.write()` method. This method accepts two arguments
 Here's an example:
 
 ```js
-fsx.write("/path/to/file.txt", "Hello world!");
+await fsx.write("/path/to/file.txt", "Hello world!");
 
 const bytes = new TextEncoder().encode("Hello world!").buffer;
 
-fsx.write("/path/to/file.txt", buffer);
+await fsx.write("/path/to/file.txt", buffer);
 ```
 
 > [!TIP]


### PR DESCRIPTION
<!--
    STOP!!! Before submitting a pull request that changes any source code, please open an issue explaining what you'd like to change first. Code changes are NOT accepted without an open issue.

    If you are only making documentation changes, you are welcome to continue without an issue.
-->

## What is the purpose of this pull request?

`fsx.write()`, `fsx.isFile()`, `fsx.delete()`, `fsx.createDirectory()`, and `fsx.isdirectory()` are async, but the `await` keyword is missing in the documentation examples.

## What changes did you make? (Give an overview)

<!--
    The following is required for all code-related changes:

    - updated documentation
    - updated tests
-->
Add missing `await` in "Writing Files", "Detecting Files", "Deleting Files", "Creating Directories", "Detecting Directories", and "Detecting Directories" examples in file and directory operations documentation.

## What issue(s) does this PR address?

<!--
    Example:

    fixes #1234
    refs #567
-->

## Is there anything you'd like reviewers to focus on?
