### PR TITLE
feat: Add EMFILE/ENFILE retrying for Node.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "fsx",
       "version": "1.0.0",
       "workspaces": [
         "packages/*"
@@ -2944,18 +2943,18 @@
     },
     "packages/core": {
       "name": "fsx-core",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "c8": "^8.0.1",
-        "fsx-types": "^0.0.0",
+        "fsx-types": "^0.0.2",
         "mocha": "^10.2.0",
         "typescript": "^5.2.2"
       }
     },
     "packages/deno": {
       "name": "fsx-deno",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.9.4",
@@ -2964,37 +2963,37 @@
     },
     "packages/memory": {
       "name": "fsx-memory",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "fsx-core": "^0.0.0"
+        "fsx-core": "^0.1.0"
       },
       "devDependencies": {
         "@types/node": "^20.9.4",
-        "fsx-test": "^0.0.0",
-        "fsx-types": "^0.0.0",
+        "fsx-test": "^0.1.0",
+        "fsx-types": "^0.0.2",
         "mocha": "^10.2.0",
         "typescript": "^5.2.2"
       }
     },
     "packages/node": {
       "name": "fsx-node",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "fsx-core": "^0.0.0"
+        "fsx-core": "^0.1.0"
       },
       "devDependencies": {
         "@types/node": "^20.9.4",
-        "fsx-test": "^0.0.0",
-        "fsx-types": "^0.0.0",
+        "fsx-test": "^0.1.0",
+        "fsx-types": "^0.0.2",
         "mocha": "^10.2.0",
         "typescript": "^5.2.2"
       }
     },
     "packages/test": {
       "name": "fsx-test",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.2.2"
@@ -3002,7 +3001,7 @@
     },
     "packages/types": {
       "name": "fsx-types",
-      "version": "0.0.0",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.2.2"
@@ -3772,7 +3771,7 @@
       "version": "file:packages/core",
       "requires": {
         "c8": "^8.0.1",
-        "fsx-types": "^0.0.0",
+        "fsx-types": "^0.0.2",
         "mocha": "^10.2.0",
         "typescript": "^5.2.2"
       }
@@ -3788,9 +3787,9 @@
       "version": "file:packages/memory",
       "requires": {
         "@types/node": "^20.9.4",
-        "fsx-core": "^0.0.0",
-        "fsx-test": "^0.0.0",
-        "fsx-types": "^0.0.0",
+        "fsx-core": "^0.1.0",
+        "fsx-test": "^0.1.0",
+        "fsx-types": "^0.0.2",
         "mocha": "^10.2.0",
         "typescript": "^5.2.2"
       }
@@ -3799,9 +3798,9 @@
       "version": "file:packages/node",
       "requires": {
         "@types/node": "^20.9.4",
-        "fsx-core": "^0.0.0",
-        "fsx-test": "^0.0.0",
-        "fsx-types": "^0.0.0",
+        "fsx-core": "^0.1.0",
+        "fsx-test": "^0.1.0",
+        "fsx-types": "^0.0.2",
         "mocha": "^10.2.0",
         "typescript": "^5.2.2"
       }

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -104,6 +104,11 @@ const fsx = new NodeFsxImpl();
 const fsx = new NodeFsxImpl({ fsp });
 ```
 
+## Errors Handled
+
+* `ENOENT` - in most cases, these errors are handled silently.
+* `ENFILE` and `EMFILE` - calls that result in these errors are retried for up to 60 seconds before giving up for good.
+
 ## License
 
 Apache 2.0

--- a/packages/node/tests/node-fsx.test.js
+++ b/packages/node/tests/node-fsx.test.js
@@ -125,7 +125,7 @@ describe("NodeFsxImpl Customizations", () => {
 			assert.strictEqual(result, "Hello world!");
 		});
 
-		it("should return text contents when EMFILE error occurs  multiple times", async () => {
+		it("should return text contents when EMFILE error occurs multiple times", async () => {
 			let callCount = 0;
 			const impl = new NodeFsxImpl({
 				fsp: {

--- a/packages/node/tests/node-fsx.test.js
+++ b/packages/node/tests/node-fsx.test.js
@@ -3,6 +3,8 @@
  * @author Nicholas C. Zakas
  */
 
+/*global describe, it, TextEncoder, Buffer */
+
 //------------------------------------------------------------------------------
 // Imports
 //------------------------------------------------------------------------------
@@ -73,6 +75,261 @@ describe("NodeFsxImpl Customizations", () => {
 				},
 			});
 			await assert.rejects(() => impl.isDirectory(".fsx/foo"), /Boom!/);
+		});
+	});
+
+	describe("text()", () => {
+		it("should return text contents when ENFILE error occurs", async () => {
+			let callCount = 0;
+			const impl = new NodeFsxImpl({
+				fsp: {
+					async readFile() {
+						if (callCount === 0) {
+							callCount++;
+							const error = new Error(
+								"ENFILE: file table overflow",
+							);
+							error.code = "ENFILE";
+							throw error;
+						}
+
+						return "Hello world!";
+					},
+				},
+			});
+
+			const result = await impl.text(".fsx/foo");
+			assert.strictEqual(result, "Hello world!");
+		});
+
+		it("should return text contents when EMFILE error occurs", async () => {
+			let callCount = 0;
+			const impl = new NodeFsxImpl({
+				fsp: {
+					async readFile() {
+						if (callCount === 0) {
+							callCount++;
+							const error = new Error(
+								"EMFILE: file table overflow",
+							);
+							error.code = "EMFILE";
+							throw error;
+						}
+
+						return "Hello world!";
+					},
+				},
+			});
+
+			const result = await impl.text(".fsx/foo");
+			assert.strictEqual(result, "Hello world!");
+		});
+
+		it("should return text contents when EMFILE error occurs  multiple times", async () => {
+			let callCount = 0;
+			const impl = new NodeFsxImpl({
+				fsp: {
+					async readFile() {
+						if (callCount < 3) {
+							callCount++;
+							const error = new Error(
+								"EMFILE: file table overflow",
+							);
+							error.code = "EMFILE";
+							throw error;
+						}
+
+						return "Hello world!";
+					},
+				},
+			});
+
+			const result = await impl.text(".fsx/foo");
+			assert.strictEqual(result, "Hello world!");
+		});
+
+		it("should rethrow an error that isn't ENFILE", async () => {
+			const impl = new NodeFsxImpl({
+				fsp: {
+					async readFile() {
+						throw new Error("Boom!");
+					},
+				},
+			});
+			await assert.rejects(() => impl.text(".fsx/foo"), /Boom!/);
+		});
+	});
+
+	describe("arrayBuffer()", () => {
+		it("should return contents when ENFILE error occurs", async () => {
+			const contents = new TextEncoder().encode("Hello world!").buffer;
+			let callCount = 0;
+			const impl = new NodeFsxImpl({
+				fsp: {
+					async readFile() {
+						if (callCount === 0) {
+							callCount++;
+							const error = new Error(
+								"ENFILE: file table overflow",
+							);
+							error.code = "ENFILE";
+							throw error;
+						}
+
+						return Buffer.from(contents);
+					},
+				},
+			});
+
+			const result = await impl.arrayBuffer(".fsx/foo");
+			assert.strictEqual(result, contents);
+		});
+
+		it("should return contents when EMFILE error occurs", async () => {
+			const contents = new TextEncoder().encode("Hello world!").buffer;
+			let callCount = 0;
+			const impl = new NodeFsxImpl({
+				fsp: {
+					async readFile() {
+						if (callCount === 0) {
+							callCount++;
+							const error = new Error(
+								"EMFILE: file table overflow",
+							);
+							error.code = "EMFILE";
+							throw error;
+						}
+
+						return Buffer.from(contents);
+					},
+				},
+			});
+
+			const result = await impl.arrayBuffer(".fsx/foo");
+			assert.strictEqual(result, contents);
+		});
+
+		it("should return text contents when EMFILE error occurs multiple times", async () => {
+			const contents = new TextEncoder().encode("Hello world!").buffer;
+			let callCount = 0;
+			const impl = new NodeFsxImpl({
+				fsp: {
+					async readFile() {
+						if (callCount < 3) {
+							callCount++;
+							const error = new Error(
+								"EMFILE: file table overflow",
+							);
+							error.code = "EMFILE";
+							throw error;
+						}
+
+						return Buffer.from(contents);
+					},
+				},
+			});
+
+			const result = await impl.arrayBuffer(".fsx/foo");
+			assert.strictEqual(result, contents);
+		});
+
+		it("should rethrow an error that isn't ENFILE", async () => {
+			const impl = new NodeFsxImpl({
+				fsp: {
+					async readFile() {
+						throw new Error("Boom!");
+					},
+				},
+			});
+			await assert.rejects(() => impl.arrayBuffer(".fsx/foo"), /Boom!/);
+		});
+	});
+
+	describe("write()", () => {
+		it("should return contents when ENFILE error occurs", async () => {
+			let callCount = 0;
+			let success = false;
+			const impl = new NodeFsxImpl({
+				fsp: {
+					async writeFile() {
+						if (callCount === 0) {
+							callCount++;
+							const error = new Error(
+								"ENFILE: file table overflow",
+							);
+							error.code = "ENFILE";
+							throw error;
+						}
+
+						success = true;
+					},
+				},
+			});
+
+			await impl.write(".fsx/foo", "Hello world!");
+			assert.ok(success);
+		});
+
+		it("should return contents when EMFILE error occurs", async () => {
+			let callCount = 0;
+			let success = false;
+			const impl = new NodeFsxImpl({
+				fsp: {
+					async writeFile() {
+						if (callCount === 0) {
+							callCount++;
+							const error = new Error(
+								"EMFILE: file table overflow",
+							);
+							error.code = "EMFILE";
+							throw error;
+						}
+
+						success = true;
+					},
+				},
+			});
+
+			await impl.write(".fsx/foo", "Hello world!");
+			assert.ok(success);
+		});
+
+		it("should return text contents when EMFILE error occurs multiple times", async () => {
+			let callCount = 0;
+			let success = false;
+			const impl = new NodeFsxImpl({
+				fsp: {
+					async writeFile() {
+						if (callCount < 3) {
+							callCount++;
+							const error = new Error(
+								"EMFILE: file table overflow",
+							);
+							error.code = "EMFILE";
+							throw error;
+						}
+
+						success = true;
+					},
+				},
+			});
+
+			await impl.write(".fsx/foo", "Hello world!");
+			assert.ok(success);
+		});
+
+		it("should rethrow an error that isn't ENFILE", async () => {
+			const impl = new NodeFsxImpl({
+				fsp: {
+					async writeFile() {
+						throw new Error("Boom!");
+					},
+				},
+			});
+			await assert.rejects(
+				() => impl.write(".fsx/foo", "Hello world!"),
+				/Boom!/,
+			);
 		});
 	});
 });


### PR DESCRIPTION
<!--
    STOP!!! Before submitting a pull request that changes any source code, please open an issue explaining what you'd like to change first. Code changes are NOT accepted without an open issue.

    If you are only making documentation changes, you are welcome to continue without an issue.
-->

## What is the purpose of this pull request?

Adds ENFILE/EMFILE retrying to the `NodeFsxImpl` class.

## What changes did you make? (Give an overview)

- Applied retry to `text()` and `arrayBuffer()`
- Applied retry to `write()`
- Added tests to verify

<!--
    The following is required for all code-related changes:

    - updated documentation
    - updated tests
-->

## What issue(s) does this PR address?

refs #9

<!--
    Example:

    fixes #1234
    refs #567
-->

## Is there anything you'd like reviewers to focus on?
