### PR TITLE
feat: Add list() method

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,3 +1,21 @@
+# 2024-01-18 The `list()` method should return an async iterable
+
+## Background
+
+Different runtimes have different interfaces for reading entries in a directory: Node.js returns `Promise<Array<string>>` by default while Deno returns `AsyncIterable<DirEnt>`.
+
+## Decision
+
+The `list()` method should return an `AsyncIterable<DirEnt>`.
+
+## Rationale
+
+Node.js' interface really only works with normal file system where everything about it is known ahead of time. For where this project wants to go, implementing impls for cloud drives, it's just not practical to return all of the entries in a directory at once. It's clear that Deno's interface allows for the possibility of returning batches of results and only fetching further results when needed, which is exactly what this project needs for cloud drives.
+
+## Related
+
+* https://github.com/humanwhocodes/fsx/issues/10
+
 # 2024-01-18 `arrayBuffer()` should be replaced by `bytes()`
 
 ## Background

--- a/docs/directory-operations.md
+++ b/docs/directory-operations.md
@@ -37,3 +37,19 @@ await fsx.delete("/path/to/directories");
 
 > [!IMPORTANT]
 > This method acts like `rm -rf`, so it will delete directories that aren't empty.
+
+## Reading Directory Entries
+
+To read all of the entries in a given directory, use the `fsx.list()` method. This method returns an async iterable and is meant to be used with the `for await-of` statement:
+
+```js
+for await (const entry of fsx.list("/path/to/directory")) {
+	if (entry.isFile) {
+		processFile(entry.name);
+	} else if (entry.isDirectory) {
+		processDirectory(entry.name)
+	}
+}
+```
+
+Each entry in the async iterator implements the [`FsxDirectoryEntry` interface](../packages/types/src/fsx-types.ts).

--- a/packages/core/src/fsx.js
+++ b/packages/core/src/fsx.js
@@ -8,6 +8,7 @@
 //-----------------------------------------------------------------------------
 
 /** @typedef{import("fsx-types").FsxImpl} FsxImpl */
+/** @typedef{import("fsx-types").FsxDirectoryEntry} FsxDirectoryEntry */
 
 //-----------------------------------------------------------------------------
 // Helpers
@@ -349,5 +350,18 @@ export class Fsx {
 	async delete(fileOrDirPath) {
 		assertValidFileOrDirPath(fileOrDirPath);
 		return this.#callImplMethod("delete", fileOrDirPath);
+	}
+
+	/**
+	 * Returns a list of directory entries for the given path.
+	 * @param {string} dirPath The path to the directory to read.
+	 * @returns {AsyncIterable<FsxDirectoryEntry>} A promise that resolves with the
+	 *   directory entries.
+	 * @throws {TypeError} If the directory path is not a string.
+	 * @throws {Error} If the directory cannot be read.
+	 */
+	async *list(dirPath) {
+		assertValidFileOrDirPath(dirPath);
+		yield* await this.#callImplMethod("list", dirPath);
 	}
 }

--- a/packages/core/tests/fsx.test.js
+++ b/packages/core/tests/fsx.test.js
@@ -796,4 +796,65 @@ describe("Fsx", () => {
 			);
 		});
 	});
+
+	describe("list()", () => {
+		it("should return the list of files", async () => {
+			const data = [
+				{
+					name: "file1.txt",
+					isFile: true,
+					isDirectory: false,
+					isSymlink: false,
+				},
+				{
+					name: "file2.txt",
+					isFile: true,
+					isDirectory: false,
+					isSymlink: false,
+				},
+				{
+					name: "file3.txt",
+					isFile: true,
+					isDirectory: false,
+					isSymlink: false,
+				},
+				{
+					name: "subdir",
+					isFile: false,
+					isDirectory: true,
+					isSymlink: false,
+				},
+			];
+
+			const fsx = new Fsx({
+				impl: {
+					list() {
+						return data;
+					},
+				},
+			});
+
+			const result = await fsx.list("/path/to/dir");
+			assert.ok(
+				result[Symbol.asyncIterator],
+				"list() should return an AsyncIterable.",
+			);
+
+			const entries = [];
+			for await (const entry of result) {
+				entries.push(entry);
+			}
+
+			assert.strictEqual(entries.length, data.length);
+
+			for (const entry of data) {
+				const item = entries.find(item => item.name === entry.name);
+				assert.ok(item, `Could not find item with name ${entry.name}.`);
+
+				assert.strictEqual(item.isDirectory, entry.isDirectory);
+				assert.strictEqual(item.isFile, entry.isFile);
+				assert.strictEqual(item.isSymlink, entry.isSymlink);
+			}
+		});
+	});
 });

--- a/packages/deno/src/deno-fsx.js
+++ b/packages/deno/src/deno-fsx.js
@@ -8,7 +8,8 @@
 // Types
 //-----------------------------------------------------------------------------
 
-/** @typedef{import("fsx-types").FsxImpl} FsxImpl */
+/** @typedef {import("fsx-types").FsxImpl} FsxImpl */
+/** @typedef {import("fsx-types").FsxDirectoryEntry} FsxDirectoryEntry */
 
 //-----------------------------------------------------------------------------
 // Imports
@@ -226,6 +227,16 @@ export class DenoFsxImpl {
 	 */
 	delete(fileOrDirPath) {
 		return this.#deno.remove(fileOrDirPath, { recursive: true });
+	}
+
+	/**
+	 * Lists the files and directories in a directory.
+	 * @param {string} dirPath The path to the directory to list.
+	 * @returns {AsyncIterable<FsxDirectoryEntry>} An async iterator
+	 *  that yields the files and directories in the directory.
+	 */
+	async *list(dirPath) {
+		yield* this.#deno.readDir(dirPath);
 	}
 }
 

--- a/packages/memory/src/memory-fsx.js
+++ b/packages/memory/src/memory-fsx.js
@@ -9,6 +9,7 @@
 //-----------------------------------------------------------------------------
 
 /** @typedef{import("fsx-types").FsxImpl} FsxImpl */
+/** @typedef{import("fsx-types").FsxDirectoryEntry} FsxDirectoryEntry */
 
 //-----------------------------------------------------------------------------
 // Imports
@@ -326,6 +327,33 @@ export class MemoryFsxImpl {
 		const { object, key } = location;
 
 		delete object[key];
+	}
+
+	/**
+	 * Returns a list of directory entries for the given path.
+	 * @param {string} dirPath The path to the directory to read.
+	 * @returns {AsyncIterable<FsxDirectoryEntry>} A promise that resolves with the
+	 *   directory entries.
+	 */
+	async *list(dirPath) {
+		const location = findPath(this.#volume, dirPath);
+
+		if (!location) {
+			throw new Error(
+				`ENOENT: no such file or directory, unlink '${dirPath}'`,
+			);
+		}
+
+		const { object, key } = location;
+
+		for (const [name, value] of Object.entries(object[key])) {
+			yield {
+				name,
+				isDirectory: isDirectory(value),
+				isFile: isFile(value),
+				isSymlink: false,
+			};
+		}
 	}
 }
 

--- a/packages/types/src/fsx-types.ts
+++ b/packages/types/src/fsx-types.ts
@@ -77,4 +77,42 @@ export interface FsxImpl {
 	 * @throws {Error} If the file or directory cannot be deleted.
 	 */
 	delete?(fileOrDirPath: string): Promise<void>;
+
+	/**
+	 * Returns a list of directory entries for the given path.
+	 * @param dirPath The path to the directory to read.
+	 * @returns A promise that resolves with the
+	 *   directory entries.
+	 * @throws {TypeError} If the directory path is not a string.
+	 * @throws {Error} If the directory cannot be read.
+	 */
+	list?(dirPath:string): AsyncIterable<FsxDirectoryEntry>;
+}
+
+//------------------------------------------------------------------------------
+// FsxDirEnt
+//------------------------------------------------------------------------------
+
+export interface FsxDirectoryEntry {
+
+	/**
+	 * The name of the file or directory.
+	 */
+	name: string;
+
+	/**
+	 * True if the entry is a directory, false if not.
+	 */
+	isDirectory: boolean;
+
+	/**
+	 * True if the entry is a file, false if not.
+	 */
+	isFile: boolean;
+
+	/**
+	 * True if the entry is a symbolic link, false if not.
+	 */
+	isSymlink: boolean;
+
 }


### PR DESCRIPTION
<!--
    STOP!!! Before submitting a pull request that changes any source code, please open an issue explaining what you'd like to change first. Code changes are NOT accepted without an open issue.

    If you are only making documentation changes, you are welcome to continue without an issue.
-->

## What is the purpose of this pull request?

Implements a `list()` method for `Fsx` and `FsxImpl` that allows reading a directory's contents.

## What changes did you make? (Give an overview)

- added method to `Fsx`
- added tests for `Fsx`
- added method to `FsxImpl`
- added method to `NodeFsxImpl`
- added method to `DenoFsxImpl`
- added method to `MemoryFsxImpl`
- added tests to `FsxImplTester`
- added tests for all other impls

<!--
    The following is required for all code-related changes:

    - updated documentation
    - updated tests
-->

## What issue(s) does this PR address?

fixes #10

<!--
    Example:

    fixes #1234
    refs #567
-->

## Is there anything you'd like reviewers to focus on?
