### PR TITLE
feat!: Safer delete(); new deleteAll() method

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,3 +1,21 @@
+# 2024-01-22 The `delete()` method should only delete files and empty directories
+
+## Background
+
+Originally, the `delete()` method would delete either files or directories, whether empty or not, depending on the path it was passed.
+
+## Decision
+
+The `delete()` method should only delete files and empty directories. A new method, `deleteAll()`, should be created to delete directories.
+
+## Rationale
+
+While convenient to have just one method to delete both files and directories, it also introduces the possibility that someone could *think* they are deleting a file but actually be deleting a full directory. Deleting a full directory recursively is a much more destructive action than deleting a file, so it makes sense to protect against that case. By splitting `deleteAll()` off from `delete()`, the code now makes it obvious that you are choosing the more destructive option explicitly. This also mimics the Deno functionality where `remove(path)` can be used to delete files and empty directories while `remove(path, {recursive:true})` deletes files and recursively deletes directories.
+
+## Related
+
+* https://github.com/humanwhocodes/fsx/discussions/22
+
 # 2024-01-18 The `list()` method should return an async iterable
 
 ## Background

--- a/packages/core/src/fsx.js
+++ b/packages/core/src/fsx.js
@@ -345,15 +345,27 @@ export class Fsx {
 	}
 
 	/**
-	 * Deletes the given file or directory.
-	 * @param {string} fileOrDirPath The file or directory to delete.
-	 * @returns {Promise<void>} A promise that resolves when the file or directory is deleted.
+	 * Deletes the given file.
+	 * @param {string} filePath The file to delete.
+	 * @returns {Promise<void>} A promise that resolves when the file is deleted.
 	 * @throws {NoSuchMethodError} When the method does not exist on the current implementation.
-	 * @throws {TypeError} When the file or directory path is not a non-empty string.
+	 * @throws {TypeError} When the file path is not a non-empty string.
 	 */
-	async delete(fileOrDirPath) {
-		assertValidFileOrDirPath(fileOrDirPath);
-		return this.#callImplMethod("delete", fileOrDirPath);
+	async delete(filePath) {
+		assertValidFileOrDirPath(filePath);
+		return this.#callImplMethod("delete", filePath);
+	}
+
+	/**
+	 * Deletes the given directory.
+	 * @param {string} dirPath The directory to delete.
+	 * @returns {Promise<void>} A promise that resolves when the directory is deleted.
+	 * @throws {NoSuchMethodError} When the method does not exist on the current implementation.
+	 * @throws {TypeError} When the directory path is not a non-empty string.
+	 */
+	async deleteAll(dirPath) {
+		assertValidFileOrDirPath(dirPath);
+		return this.#callImplMethod("deleteAll", dirPath);
 	}
 
 	/**

--- a/packages/core/tests/fsx.test.js
+++ b/packages/core/tests/fsx.test.js
@@ -661,7 +661,7 @@ describe("Fsx", () => {
 
 			assert.rejects(
 				fsx.isDirectory(123),
-				new TypeError("Directory path must be a non-empty string."),
+				/Path must be a non-empty string./,
 			);
 		});
 
@@ -676,7 +676,7 @@ describe("Fsx", () => {
 
 			assert.rejects(
 				fsx.isDirectory(""),
-				new TypeError("Directory path must be a non-empty string."),
+				/Path must be a non-empty string./,
 			);
 		});
 	});
@@ -725,7 +725,7 @@ describe("Fsx", () => {
 
 			assert.rejects(
 				fsx.createDirectory(123),
-				new TypeError("Directory path must be a non-empty string."),
+				/Path must be a non-empty string./,
 			);
 		});
 
@@ -740,7 +740,7 @@ describe("Fsx", () => {
 
 			assert.rejects(
 				fsx.createDirectory(""),
-				new TypeError("Directory path must be a non-empty string."),
+				/Path must be a non-empty string./,
 			);
 		});
 	});
@@ -805,6 +805,70 @@ describe("Fsx", () => {
 			assert.rejects(
 				fsx.delete(""),
 				new TypeError("File path must be a non-empty string."),
+			);
+		});
+	});
+
+	describe("deleteAll()", () => {
+		it("should not reject a promise when the file path is a string", async () => {
+			const fsx = new Fsx({
+				impl: {
+					delete() {
+						return undefined;
+					},
+				},
+			});
+
+			await fsx.delete("/path/to/directory");
+		});
+
+		it("should log the method call", async () => {
+			const fsx = new Fsx({
+				impl: {
+					deleteAll() {
+						return undefined;
+					},
+				},
+			});
+
+			fsx.logStart("delete");
+			await fsx.deleteAll("/path/to/directory");
+			const logs = fsx.logEnd("delete").map(normalizeLogEntry);
+			assert.deepStrictEqual(logs, [
+				{
+					methodName: "deleteAll",
+					args: ["/path/to/directory"],
+				},
+			]);
+		});
+
+		it("should reject a promise when the file path is not a string", () => {
+			const fsx = new Fsx({
+				impl: {
+					deleteAll() {
+						return undefined;
+					},
+				},
+			});
+
+			assert.rejects(
+				fsx.deleteAll(123),
+				/Path must be a non-empty string./,
+			);
+		});
+
+		it("should reject a promise when the file path is empty", () => {
+			const fsx = new Fsx({
+				impl: {
+					deleteAll() {
+						return undefined;
+					},
+				},
+			});
+
+			assert.rejects(
+				fsx.deleteAll(""),
+				/Path must be a non-empty string./,
 			);
 		});
 	});

--- a/packages/deno/src/deno-fsx.js
+++ b/packages/deno/src/deno-fsx.js
@@ -224,8 +224,8 @@ export class DenoFsxImpl {
 	}
 
 	/**
-	 * Deletes a file or directory recursively.
-	 * @param {string} fileOrDirPath The path to the file or directory to
+	 * Deletes a file or empty directory.
+	 * @param {string} filePath The path to the file or directory to
 	 *   delete.
 	 * @returns {Promise<void>} A promise that resolves when the file or
 	 *   directory is deleted.
@@ -233,8 +233,22 @@ export class DenoFsxImpl {
 	 * @throws {Error} If the file or directory cannot be deleted.
 	 * @throws {Error} If the file or directory is not found.
 	 */
-	delete(fileOrDirPath) {
-		return this.#deno.remove(fileOrDirPath, { recursive: true });
+	delete(filePath) {
+		return this.#deno.remove(filePath);
+	}
+
+	/**
+	 * Deletes a file or directory recursively.
+	 * @param {string} filePath The path to the file or directory to
+	 *   delete.
+	 * @returns {Promise<void>} A promise that resolves when the file or
+	 *   directory is deleted.
+	 * @throws {TypeError} If the file or directory path is not a string.
+	 * @throws {Error} If the file or directory cannot be deleted.
+	 * @throws {Error} If the file or directory is not found.
+	 */
+	deleteAll(filePath) {
+		return this.#deno.remove(filePath, { recursive: true });
 	}
 
 	/**

--- a/packages/memory/src/memory-fsx.js
+++ b/packages/memory/src/memory-fsx.js
@@ -316,7 +316,7 @@ export class MemoryFsxImpl {
 	}
 
 	/**
-	 * Deletes a file or directory recursively.
+	 * Deletes a file or empty directory.
 	 * @param {string} fileOrDirPath The path to the file or directory to
 	 *   delete.
 	 * @returns {Promise<void>} A promise that resolves when the file or
@@ -326,6 +326,38 @@ export class MemoryFsxImpl {
 	 * @throws {Error} If the file or directory is not found.
 	 */
 	async delete(fileOrDirPath) {
+		const location = findPath(this.#volume, fileOrDirPath);
+
+		if (!location) {
+			throw new Error(
+				`ENOENT: no such file or directory, unlink '${fileOrDirPath}'`,
+			);
+		}
+
+		const { object, key } = location;
+
+		const value = object[key];
+
+		if (isDirectory(value) && Object.keys(value).length > 0) {
+			throw new Error(
+				`EISDIR: illegal operation on a directory, unlink '${fileOrDirPath}'`,
+			);
+		}
+
+		delete object[key];
+	}
+
+	/**
+	 * Deletes a file or directory recursively.
+	 * @param {string} fileOrDirPath The path to the file or directory to
+	 *   delete.
+	 * @returns {Promise<void>} A promise that resolves when the file or
+	 *   directory is deleted.
+	 * @throws {TypeError} If the file or directory path is not a string.
+	 * @throws {Error} If the file or directory cannot be deleted.
+	 * @throws {Error} If the file or directory is not found.
+	 */
+	async deleteAll(fileOrDirPath) {
 		const location = findPath(this.#volume, fileOrDirPath);
 
 		if (!location) {

--- a/packages/node/src/node-fsx.js
+++ b/packages/node/src/node-fsx.js
@@ -263,7 +263,7 @@ export class NodeFsxImpl {
 	}
 
 	/**
-	 * Deletes a file or directory recursively.
+	 * Deletes a file or empty directory.
 	 * @param {string} fileOrDirPath The path to the file or directory to
 	 *   delete.
 	 * @returns {Promise<void>} A promise that resolves when the file or
@@ -273,6 +273,26 @@ export class NodeFsxImpl {
 	 * @throws {Error} If the file or directory is not found.
 	 */
 	delete(fileOrDirPath) {
+		return this.#fsp.rm(fileOrDirPath).catch(error => {
+			if (error.code === "ERR_FS_EISDIR") {
+				return this.#fsp.rmdir(fileOrDirPath);
+			}
+
+			throw error;
+		});
+	}
+
+	/**
+	 * Deletes a file or directory recursively.
+	 * @param {string} fileOrDirPath The path to the file or directory to
+	 *   delete.
+	 * @returns {Promise<void>} A promise that resolves when the file or
+	 *   directory is deleted.
+	 * @throws {TypeError} If the file or directory path is not a string.
+	 * @throws {Error} If the file or directory cannot be deleted.
+	 * @throws {Error} If the file or directory is not found.
+	 */
+	deleteAll(fileOrDirPath) {
 		return this.#fsp.rm(fileOrDirPath, { recursive: true });
 	}
 

--- a/packages/types/src/fsx-types.ts
+++ b/packages/types/src/fsx-types.ts
@@ -71,12 +71,20 @@ export interface FsxImpl {
 	createDirectory?(dirPath: string): Promise<void>;
 
 	/**
-	 * Deletes the given file or directory.
+	 * Deletes the given file or empty directory.
 	 * @param fileOrDirPath The file or directory to delete.
 	 * @returns A promise that resolves when the file or directory is deleted.
 	 * @throws {Error} If the file or directory cannot be deleted.
 	 */
 	delete?(fileOrDirPath: string): Promise<void>;
+
+	/**
+	 * Deletes the given file or directory recursively.
+	 * @param fileOrDirPath The file or directory to delete.
+	 * @returns A promise that resolves when the file or directory is deleted.
+	 * @throws {Error} If the file or directory cannot be deleted.
+	 */
+	deleteAll?(fileOrDirPath: string): Promise<void>;
 
 	/**
 	 * Returns a list of directory entries for the given path.


### PR DESCRIPTION
<!--
    STOP!!! Before submitting a pull request that changes any source code, please open an issue explaining what you'd like to change first. Code changes are NOT accepted without an open issue.

    If you are only making documentation changes, you are welcome to continue without an issue.
-->

## What is the purpose of this pull request?

This splits up the functionality from the `delete()` method to make it safer.

## What changes did you make? (Give an overview)

* The `delete()` method now will only delete files and *empty* directories.
* The `deleteAll()` method now acts like `delete()` used to: the equivalent of `rm -r`.
* Updated type definitions for impls
* Updated `Fsx` class
* Updated all three impls

<!--
    The following is required for all code-related changes:

    - updated documentation
    - updated tests
-->

## What issue(s) does this PR address?

Refs https://github.com/humanwhocodes/fsx/discussions/22
<!--
    Example:

    fixes #1234
    refs #567
-->

## Is there anything you'd like reviewers to focus on?
