### PR TITLE
fix(types): correctly type `MemoryFsx` and `MemoryFsxImpl` constructors

### DIFF
--- a/packages/memory/src/memory-fsx.js
+++ b/packages/memory/src/memory-fsx.js
@@ -153,10 +153,10 @@ export class MemoryFsxImpl {
 
 	/**
 	 * Creates a new instance.
-	 * @param {object} options The options for the instance.
-	 * @param {object} options.volume The in-memory file system volume to use.
+	 * @param {object} [options={}] The options for the instance.
+	 * @param {object} [options.volume] The in-memory file system volume to use.
 	 */
-	constructor({ volume }) {
+	constructor({ volume } = {}) {
 		this.#volume = volume;
 	}
 
@@ -409,7 +409,7 @@ export class MemoryFsxImpl {
 export class MemoryFsx extends Fsx {
 	/**
 	 * Creates a new instance.
-	 * @param {object} options The options for the instance.
+	 * @param {object} [options={}] The options for the instance.
 	 * @param {object} [options.volume] The in-memory file system volume to use.
 	 */
 	constructor({ volume } = {}) {


### PR DESCRIPTION
## What is the purpose of this pull request?

Fixing `fsx-memory` type issues reported in #47.

## What changes did you make? (Give an overview)

- [x] Fix `MemoryFsx` and `MemoryFsxImpl` constructors types
- [x] Add default param to `MemoryFsxImpl` constructor

No documentation update needed since it was already correct.

## What issue(s) does this PR address?

Fixes #47