### PR TITLE
feat: New size() method

### DIFF
--- a/docs/file-operations.md
+++ b/docs/file-operations.md
@@ -91,3 +91,11 @@ To delete files, call the `fsx.delete(filePath)` method. For example:
 ```js
 await fsx.delete("/path/to/file.txt");
 ```
+
+## Retrieving File Size
+
+To get the size of a file in bytes, call the `fsx.size(filePath)` method. This method returns the size in bytes of the file if found and `undefined` if not found. Here's an example:
+
+```js
+const size = await fsx.size("/path/to/file.txt");
+```

--- a/packages/core/src/fsx.js
+++ b/packages/core/src/fsx.js
@@ -380,4 +380,16 @@ export class Fsx {
 		assertValidFileOrDirPath(dirPath);
 		yield* await this.#callImplMethod("list", dirPath);
 	}
+
+	/**
+	 * Returns the size of the given file.
+	 * @param {string} filePath The path to the file to read.
+	 * @returns {Promise<number>} A promise that resolves with the size of the file.
+	 * @throws {TypeError} If the file path is not a string.
+	 * @throws {Error} If the file cannot be read.
+	 */
+	async size(filePath) {
+		assertValidFileOrDirPath(filePath);
+		return this.#callImplMethod("size", filePath);
+	}
 }

--- a/packages/core/tests/fsx.test.js
+++ b/packages/core/tests/fsx.test.js
@@ -933,4 +933,69 @@ describe("Fsx", () => {
 			}
 		});
 	});
+
+	describe("size()", () => {
+		it("should return the size of the file", async () => {
+			const fsx = new Fsx({
+				impl: {
+					size() {
+						return 123;
+					},
+				},
+			});
+
+			const result = await fsx.size("/path/to/file.txt");
+			assert.strictEqual(result, 123);
+		});
+
+		it("should log the method call", async () => {
+			const fsx = new Fsx({
+				impl: {
+					size() {
+						return 123;
+					},
+				},
+			});
+
+			fsx.logStart("size");
+			await fsx.size("/path/to/file.txt");
+			const logs = fsx.logEnd("size").map(normalizeLogEntry);
+			assert.deepStrictEqual(logs, [
+				{
+					methodName: "size",
+					args: ["/path/to/file.txt"],
+				},
+			]);
+		});
+
+		it("should reject a promise when the file path is not a string", () => {
+			const fsx = new Fsx({
+				impl: {
+					size() {
+						return 123;
+					},
+				},
+			});
+
+			assert.rejects(
+				fsx.size(123),
+				new TypeError("File path must be a non-empty string."),
+			);
+		});
+
+		it("should reject a promise when the file path is empty", () => {
+			const fsx = new Fsx({
+				impl: {
+					size() {
+						return 123;
+					},
+				},
+			});
+
+			assert.rejects(
+				fsx.size(""),
+				new TypeError("File path must be a non-empty string."),
+			);
+		});
+	});
 });

--- a/packages/deno/README.md
+++ b/packages/deno/README.md
@@ -54,6 +54,9 @@ await fsx.write("file.txt", new TextEncoder().encode("Hello world!"));
 // does the file exist?
 const found = await fsx.isFile("file.txt");
 
+// how big is the file?
+const size = await fsx.size("file.txt");
+
 // delete a file
 await fsx.delete("file.txt");
 

--- a/packages/deno/src/deno-fsx.js
+++ b/packages/deno/src/deno-fsx.js
@@ -264,6 +264,25 @@ export class DenoFsxImpl {
 	async *list(dirPath) {
 		yield* this.#deno.readDir(dirPath);
 	}
+
+	/**
+	 * Returns the size of a file.
+	 * @param {string} filePath The path to the file to read.
+	 * @returns {Promise<number|undefined>} A promise that resolves with the size of the
+	 *  file in bytes or undefined if the file doesn't exist.
+	 */
+	size(filePath) {
+		return this.#deno
+			.stat(filePath)
+			.then(stat => stat.size)
+			.catch(error => {
+				if (error.code === "ENOENT") {
+					return undefined;
+				}
+
+				throw error;
+			});
+	}
 }
 
 /**

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -102,6 +102,9 @@ await fsx.write("file.txt", new TextEncoder().encode("Hello world!"));
 // does the file exist?
 const found = await fsx.isFile("file.txt");
 
+// how big is the file?
+const size = await fsx.size("file.txt");
+
 // delete a file
 await fsx.delete("file.txt");
 

--- a/packages/memory/src/memory-fsx.js
+++ b/packages/memory/src/memory-fsx.js
@@ -400,6 +400,27 @@ export class MemoryFsxImpl {
 			};
 		}
 	}
+
+	/**
+	 * Returns the size of a file.
+	 * @param {string} filePath The path to the file to read.
+	 * @returns {Promise<number|undefined>} A promise that resolves with the size of the
+	 *  file in bytes or undefined if the file doesn't exist.
+	 */
+	async size(filePath) {
+		const value = readPath(this.#volume, filePath);
+
+		if (!isFile(value)) {
+			return undefined;
+		}
+
+		if (value instanceof ArrayBuffer) {
+			return value.byteLength;
+		}
+
+		// use byteLength for strings for accuracy
+		return new TextEncoder().encode(value).byteLength;
+	}
 }
 
 /**

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -62,6 +62,9 @@ await fsx.write("file.txt", new TextEncoder().encode("Hello world!"));
 // does the file exist?
 const found = await fsx.isFile("file.txt");
 
+// how big is the file?
+const size = await fsx.size("file.txt");
+
 // delete a file
 await fsx.delete("file.txt");
 

--- a/packages/node/src/node-fsx.js
+++ b/packages/node/src/node-fsx.js
@@ -317,6 +317,25 @@ export class NodeFsxImpl {
 			yield new NodeFsxDirectoryEntry(entry);
 		}
 	}
+
+	/**
+	 * Returns the size of a file.
+	 * @param {string} filePath The path to the file to read.
+	 * @returns {Promise<number|undefined>} A promise that resolves with the size of the
+	 *  file in bytes or undefined if the file doesn't exist.
+	 */
+	size(filePath) {
+		return this.#fsp
+			.stat(filePath)
+			.then(stat => stat.size)
+			.catch(error => {
+				if (error.code === "ENOENT") {
+					return undefined;
+				}
+
+				throw error;
+			});
+	}
 }
 
 /**

--- a/packages/test/src/fsx-impl-tester.js
+++ b/packages/test/src/fsx-impl-tester.js
@@ -504,6 +504,20 @@ export class FsxImplTester {
 					}
 				});
 			});
+
+			describe("size()", () => {
+				it("should return the size of a file", async () => {
+					const filePath = this.#outputDir + "/hello.txt";
+					const result = await impl.size(filePath);
+					assert.strictEqual(result, 13);
+				});
+
+				it("should return undefined if the file doesn't exist", async () => {
+					const filePath = this.#outputDir + "/nonexistent.txt";
+					const result = await impl.size(filePath);
+					assert.strictEqual(result, undefined);
+				});
+			});
 		});
 	}
 }

--- a/packages/types/src/fsx-types.ts
+++ b/packages/types/src/fsx-types.ts
@@ -95,6 +95,15 @@ export interface FsxImpl {
 	 * @throws {Error} If the directory cannot be read.
 	 */
 	list?(dirPath:string): AsyncIterable<FsxDirectoryEntry>;
+
+	/**
+	 * Returns the size of the given file.
+	 * @param filePath The path to the file to check.
+	 * @returns A promise that resolves with the size of the file in bytes or
+	 * 		undefined if the file does not exist.
+	 * @throws {Error} If the file cannot be read.
+	 */
+	size?(filePath: string): Promise<number|undefined>;
 }
 
 //------------------------------------------------------------------------------

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -56,6 +56,9 @@ await fsx.write("file.txt", new TextEncoder().encode("Hello world!"));
 // does the file exist?
 const found = await fsx.isFile("file.txt");
 
+// how big is the file?
+const size = await fsx.size("file.txt");
+
 // delete a file
 await fsx.delete("file.txt");
 

--- a/packages/web/src/web-fsx.js
+++ b/packages/web/src/web-fsx.js
@@ -407,6 +407,24 @@ export class WebFsxImpl {
 			};
 		}
 	}
+
+	/**
+	 * Returns the size of a file.
+	 * @param {string} filePath The path to the file to read.
+	 * @returns {Promise<number|undefined>} A promise that resolves with the size of the
+	 *  file in bytes or undefined if the file doesn't exist.
+	 */
+	async size(filePath) {
+		const handle = await findPath(this.#root, filePath);
+
+		if (!handle || handle.kind !== "file") {
+			return undefined;
+		}
+
+		const fileHandle = /** @type {FileSystemFileHandle} */ (handle);
+		const file = await fileHandle.getFile();
+		return file.size;
+	}
 }
 
 /**


### PR DESCRIPTION
<!--
    STOP!!! Before submitting a pull request that changes any source code, please open an issue explaining what you'd like to change first. Code changes are NOT accepted without an open issue.

    If you are only making documentation changes, you are welcome to continue without an issue.
-->

## What is the purpose of this pull request?

Adds a new `size()` method to retrieve the size of a file.

## What changes did you make? (Give an overview)

- Added `size()` to `Fsx`, `FsxImpl`, `NodeFsx`, `DenoFsx`, `MemoryFsx`, and `WebFsx`.
- Updated `FsxImplTester` to test `size()`.
- Updated the documentation.

<!--
    The following is required for all code-related changes:

    - updated documentation
    - updated tests
-->

## What issue(s) does this PR address?

<!--
    Example:

    fixes #1234
    refs #567
-->

## Is there anything you'd like reviewers to focus on?
